### PR TITLE
[FIX]web: KeyError when select m2o or m2m fields in export screen with

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1673,7 +1673,7 @@ class Export(http.Controller):
         fields = self.fields_get(model)
         if import_compat:
             if parent_field_type in ['many2one', 'many2many']:
-                fields = {'id': fields['id'], 'name': fields['name']}
+                fields = {'id': fields['id'], 'name': fields[request.env[model]._rec_name]}
         else:
             fields['.id'] = {**fields['id']}
 

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1672,9 +1672,9 @@ class Export(http.Controller):
 
         fields = self.fields_get(model)
         rec_name = request.env[model]._rec_name
-        if import_compat:
-            if parent_field_type in ['many2one', 'many2many']:
-                fields = {k: v for k, v in fields.items() if k in ['id', rec_name]}
+        if import_compat:            
+            if parent_field_type in ['many2one', 'many2many']:                
+                fields = {'id': fields['id'], 'name': fields[rec_name]}
         else:
             fields['.id'] = {**fields['id']}
 
@@ -1702,7 +1702,7 @@ class Export(http.Controller):
 
             id = prefix + (prefix and '/'or '') + field_name
             val = id
-            if field_name == rec_name and import_compat and parent_field_type in ['many2one', 'many2many']:
+            if field_name == 'name' and import_compat and parent_field_type in ['many2one', 'many2many']:
                 # Add name field when expand m2o and m2m fields in import-compatible mode
                 val = prefix
             name = parent_name + (parent_name and '/' or '') + field['string']

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1671,9 +1671,10 @@ class Export(http.Controller):
                    parent_field=None, exclude=None):
 
         fields = self.fields_get(model)
+        rec_name = request.env[model]._rec_name
         if import_compat:
             if parent_field_type in ['many2one', 'many2many']:
-                fields = {'id': fields['id'], 'name': fields['name']}
+                fields = {k: v for k, v in fields.items() if k in ['id', rec_name]}
         else:
             fields['.id'] = {**fields['id']}
 
@@ -1701,7 +1702,7 @@ class Export(http.Controller):
 
             id = prefix + (prefix and '/'or '') + field_name
             val = id
-            if field_name == 'name' and import_compat and parent_field_type in ['many2one', 'many2many']:
+            if field_name == rec_name and import_compat and parent_field_type in ['many2one', 'many2many']:
                 # Add name field when expand m2o and m2m fields in import-compatible mode
                 val = prefix
             name = parent_name + (parent_name and '/' or '') + field['string']


### PR DESCRIPTION
"import-compatible export" enalbed
# Conflicts:
#	addons/web/controllers/main.py

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
